### PR TITLE
Shard name conflict

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: web3
-version: 0.1.1
+version: 0.1.0
 
 authors:
   - Tamás Szekeres <szektam2@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
-name: web3.cr
-version: 0.1.0
+name: web3
+version: 0.1.1
 
 authors:
   - Tamás Szekeres <szektam2@gmail.com>


### PR DESCRIPTION
It's currently impossible to use the web3 shard.

`require "web3"`

generates a build error about a lib not found, if you define

`  web3.cr:
    github: light-side-software/web3.cr
`

in shard.yml.

You can use the following now

`  web3:
    github: light-side-software/web3.cr
`